### PR TITLE
Fix dm error

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: "1.2.0"
+cff-version: "1.2.1"
 message: "If you use this software, please cite it as below."
 authors:
 - family-names: "De Zitter"
@@ -12,7 +12,7 @@ authors:
 - family-names: "Colletier"
   given-names: "Jacques-Philippe"
 title: "Xtrapol8"
-version: "v1.2.0"
+version: "v1.2.1"
 doi: "10.5281/zenodo.6560832"
 date-released: "2022-12-06"
 url: "https://github.com/ElkeDeZitter/Xtrapol8"

--- a/Fextr.py
+++ b/Fextr.py
@@ -2104,7 +2104,7 @@ class Filesandmaps(object):
 
 def run(args):
     
-    version = "1.2.0"
+    version = "1.2.1"
     now = datetime.now().strftime('%Y-%m-%d_%Hh%M')
     print('-----------------------------------------')
     print("Xtrapol8 -- version %s -- run date: %s" %(version, now))

--- a/Fextr.py
+++ b/Fextr.py
@@ -1634,7 +1634,7 @@ class Fextrapolate(object):
                 print("    mtz-file not found. Density modification failed.")
 
         print("REAL SPACE REFINEMENT WITH %s AND %s" %(mtz_map, pdb_in))
-        pdb_out_real = ref.phenix_real_space_refinement(mtz_map, pdb_in, column_labels)
+        pdb_out_real = ref.phenix_real_space_refinement_mtz(mtz_map, pdb_in, column_labels)
         print("Output real space refinement:", file=log)
         print("----------------")
         print("Output real space refinement:")
@@ -1648,8 +1648,10 @@ class Fextrapolate(object):
         print("----------------")
 
         if (keywords.density_modification.density_modification and os.path.isfile(mtz_dm)):
-            print("REAL SPACE REFINEMENT WITH %s AND %s" %(mtz_dm, pdb_out_rec))
-            pdb_out_rec_real = ref.phenix_real_space_refinement(mtz_dm, pdb_out_rec, 'FWT,PHWT')
+            ccp4_dm = re.sub(r".mtz$", ".ccp4", mtz_dm)
+            _, high_res = ref.get_mtz_resolution(mtz_dm)
+            print("REAL SPACE REFINEMENT WITH %s AND %s" %(ccp4_dm, pdb_out_rec))
+            pdb_out_rec_real = ref.phenix_real_space_refinement_ccp4(ccp4_dm, pdb_out_rec, high_res)
             print("Output real space refinement after reciprocal space refinement:", file=log)
             print("----------------")
             print("Output real space refinement after reciprocal space refinement:")
@@ -1663,7 +1665,7 @@ class Fextrapolate(object):
             print("----------------")
         else:
             print("REAL SPACE REFINEMENT WITH %s AND %s" %(mtz_out_rec, pdb_out_rec))
-            pdb_out_rec_real = ref.phenix_real_space_refinement(mtz_out_rec, pdb_out_rec, '2FOFCWT,PH2FOFCWT')
+            pdb_out_rec_real = ref.phenix_real_space_refinement_mtz(mtz_out_rec, pdb_out_rec, '2FOFCWT,PH2FOFCWT')
             print("Output real space refinement after reciprocal space refinement:", file=log)
             print("----------------")
             print("Output real space refinement after reciprocal space refinement:")

--- a/Fextr.py
+++ b/Fextr.py
@@ -3089,14 +3089,14 @@ def run(args):
             else:
                 mtz_rec = recref_mtz_lst[params.occupancies.list_occ.index(occ)]
             append_if_file_exist(mtzs_for_coot, mtz_rec)
-            if params.refinement.phenix_keywords.density_modification.density_modification:
+            if ( params.refinement.phenix_keywords.density_modification.density_modification or params.refinement.refmac_keywords.density_modification.density_modification):
                 #mtz_dm = re.sub(".mtz$","_densitymod.mtz", mtz_rec)
                 mtz_dm = re.sub(".mtz$","_dm.mtz", mtz_rec)
                 append_if_file_exist(mtzs_for_coot, mtz_dm)
 
-            if params.refinement.refmac_keywords.density_modification.density_modification:
-                mtz_dm = re.sub(".mtz$","_dm.mtz", mtz_rec)
-                append_if_file_exist(mtzs_for_coot, mtz_dm)
+            #if params.refinement.refmac_keywords.density_modification.density_modification:
+                #mtz_dm = re.sub(".mtz$","_dm.mtz", mtz_rec)
+                #append_if_file_exist(mtzs_for_coot, mtz_dm)
             mtz_extr = ["%s/%s"%(occ_dir,fle) for fle in os.listdir(occ_dir) if outname in fle and fle.endswith('m%s-DFc.mtz'%(mp_type))][0]
             append_if_file_exist(mtzs_for_coot,os.path.abspath(mtz_extr))
 

--- a/Fextr.py
+++ b/Fextr.py
@@ -1771,7 +1771,7 @@ class Fextrapolate(object):
         print("----------------")
 
         print("REAL SPACE REFINEMENT WITH %s AND %s" %(mtz_map, pdb_in))
-        pdb_out_real = ref.coot_real_space_refinement(pdb_in, mtz_map, map_column_labels)
+        pdb_out_real = ref.coot_real_space_refinement_mtz(pdb_in, mtz_map, map_column_labels)
         print("output real space refinement:", file=log)
         print("----------------")
         print("output real space refinement:")
@@ -1785,8 +1785,9 @@ class Fextrapolate(object):
         print("----------------")
 
         if keywords.density_modification.density_modification:
-            print("REAL SPACE REFINEMENT WITH %s AND %s" %(mtz_dm, pdb_out_rec))
-            pdb_out_rec_real = ref.coot_real_space_refinement(pdb_out_rec, mtz_dm, 'PHIDM, FOMDM, FOFCWT, PHFOFCWT' )
+            ccp4_dm = re.sub(r".mtz$", ".ccp4", mtz_dm)
+            print("REAL SPACE REFINEMENT WITH %s AND %s" %(ccp4_dm, pdb_out_rec))
+            pdb_out_rec_real = ref.coot_real_space_refinement_ccp4(pdb_out_rec, ccp4_dm)
             print("output real space refinement after reciprocal space refinement:", file=log)
             print("----------------")
             print("output real space refinement after reciprocal space refinement:")
@@ -1800,7 +1801,7 @@ class Fextrapolate(object):
             print("----------------")
         else:
             print("REAL SPACE REFINEMENT WITH %s AND %s" %(mtz_out_rec, pdb_out_rec))
-            pdb_out_rec_real = ref.coot_real_space_refinement(pdb_out_rec, mtz_out_rec, '2FOFCWT, PH2FOFCWT, FOFCWT, PHFOFCWT')
+            pdb_out_rec_real = ref.coot_real_space_refinement_mtz(pdb_out_rec, mtz_out_rec, '2FOFCWT, PH2FOFCWT, FOFCWT, PHFOFCWT')
             print("output real space refinement after reciprocal space refinement:", file=log)
             print("----------------")
             print("output real space refinement after reciprocal space refinement:")

--- a/Fextr_utils.py
+++ b/Fextr_utils.py
@@ -215,7 +215,9 @@ def open_all_in_coot(FoFo, pdb_list, mtz_list, additional, outdir=os.getcwd(), s
                 mtz_content = any_file(mtz,force_type="hkl").file_object.file_content()
                 if '2FOFCWT' in mtz_content.column_labels(): #maps from refinement program
                     default_mtz_lines+='auto_read_make_and_draw_maps_from_mtz("%s")\n'%(mtz)
-                elif mtz_content.column_labels() == ['H', 'K', 'L', 'FP', 'SIGFP', 'PHIB', 'FOM', 'HLA', 'HLB', 'HLC', 'HLD', 'FWT', 'PHWT']: #from phenix.density_modification
+                elif 'FDM' in mtz_content.column_labels(): #maps from dm
+                    default_mtz_lines+='auto_read_make_and_draw_maps_from_mtz("%s")\n'%(mtz)
+                elif mtz_content.column_labels() == ['H', 'K', 'L', 'FP', 'SIGFP', 'PHIB', 'FOM', 'HLA', 'HLB', 'HLC', 'HLD', 'FWT', 'PHWT']: #from phenix.density_modification # not used anymore
                     default_mtz_lines+='auto_read_make_and_draw_maps_from_mtz("%s")\n'%(mtz)
                 else:
                     if mtz_content.column_types() == ['H', 'H', 'H', 'F', 'P', 'F', 'P']:

--- a/phenix_refinements.py
+++ b/phenix_refinements.py
@@ -30,6 +30,7 @@ from libtbx import adopt_init_args
 from cctbx import miller
 from Fextr_utils import get_name
 import subprocess
+from iotbx.file_reader import any_file
 
 
 class Phenix_refinements(object):
@@ -153,23 +154,41 @@ class Phenix_refinements(object):
         
         return mtz_out, pdb_out
     
-    def phenix_real_space_refinement(self, mtz_in, pdb_in, column_labels):
+    def get_phenix_version(self):
         """
-        use Bash line to run phenix.real_space_refine as usual (use of os.system is bad practice).
-        Some parameters have changed between version 1.7, 1.8 and 1.9 hence the weird construction to grap the version
-        """       
-        
-        mtz_name = get_name(mtz_in)
-            
-        #Spacify phenix version dependent parameters
+        Weird construction to get the phenix version. This is required since some parameter names change between versions
+        """
         try:
             phenix_version = int(re.search(r"phenix-1\.(.+?)\.", miller.__file__).group(1)) #This is not so robust. relies on the format being 'phenix.1.18.something' or 'phenix.1.18-something'
         except ValueError:
                 phenix_version = int(re.search(r"phenix-1\.(.+?)\-", miller.__file__).group(1))
         except AttributeError:
-            print('Update phenix! Verify that you are using at least Phenix.1.17.')
-            phenix_version = 19 #let's assume then that the latest phenix is installed in case this fails for other reasons than a very old phenix version
+            print('Update phenix! Verify that you are using at least Phenix.1.19.')
+            phenix_version = 20 #let's assume then that the latest phenix is installed in case this fails for other reasons than a very old phenix version
+        
+        return phenix_version
+    
+    def get_mtz_resolution(self, mtz_in):
+        """
+        Easy extraction of the resolution boundaries of an mtz file
+        """
+        reflections = any_file(mtz_in, force_type="hkl", raise_sorry_if_errors=True)
+        low_res, high_res = reflections.file_content.file_content().max_min_resolution()
+         
+        return low_res, high_res
+        
+    
+    def phenix_real_space_refinement_mtz(self, mtz_in, pdb_in, column_labels):
+        """
+        Real space refinement based on mtz file and specified column labels
+        use Bash line to run phenix.real_space_refine as usual (use of os.system is bad practice).
+        Some parameters have changed between version 1.17, 1.18 and 1.19 hence the weird construction to grap the version
+        """       
+        
+        mtz_name = get_name(mtz_in)
             
+        #Specify phenix version dependent parameters
+        phenix_version = self.get_phenix_version()
         print("Phenix version 1.%d" %(phenix_version))
         
         if phenix_version >= 18:
@@ -221,6 +240,70 @@ class Phenix_refinements(object):
             outpdb = "not_a_file"
 
         return outpdb
+    
+    def phenix_real_space_refinement_ccp4(self, ccp4_in, pdb_in, resolution):
+        """
+        Real space refinement based on ccp4 file
+        use Bash line to run phenix.real_space_refine as usual (use of os.system is bad practice).
+        Some parameters have changed between version 1.7, 1.8 and 1.9 hence the weird construction to grap the version
+        """       
+        
+        ccp4_name = get_name(ccp4_in)
+            
+        #Specify phenix version dependent parameters
+        phenix_version = self.get_phenix_version()
+        print("Phenix version 1.%d" %(phenix_version))
+        
+        if phenix_version >= 18:
+            rotamer_restraints = 'rotamers.restraints.enabled=False' #rotamers.fit=all?
+        else:
+            rotamer_restraints = 'rotamer_restraints=False'
+            
+        if phenix_version >= 19:
+            output_prefix = 'output.prefix=%s'%(ccp4_name)
+            model_format  = 'model_format=pdb'
+            # outpdb        = "%s_real_space_refined_000.pdb"%(ccp4_name)
+            ramachandran_restraints = 'ramachandran_plot_restraints.enable=False'
+        else:
+            output_prefix = 'output.file_name_prefix=%s'%(ccp4_name)
+            model_format  = 'output.model_format=pdb'
+            # outpdb        = "%s_real_space_refined.pdb"%(ccp4_name)
+            ramachandran_restraints = 'ramachandran_restraints=False'
+            
+        additional_keywords_line = ''
+        if len(self.additional_real_keywords) > 0:
+            for keyword in self.additional_real_keywords:
+                additional_keywords_line+= "%s " %(keyword)
+ 
+        
+        real = os.system("phenix.real_space_refine %s %s %s "
+                        "geometry_restraints.edits.excessive_bond_distance_limit=1000 refinement.run=minimization_global+adp scattering_table=n_gaussian c_beta_restraints=False %s refinement.macro_cycles=%d refinement.simulated_annealing=every_macro_cycle nproc=4 %s %s %s ignore_symmetry_conflicts=True resolution=%.2f %s" %(ccp4_in, self.additional, pdb_in, output_prefix, self.real_cycles, model_format, rotamer_restraints, ramachandran_restraints, resolution, additional_keywords_line))
+
+        #Find output file
+        if real == 0 : #os.system has correctly finished. Then search for the last refined structure
+            if phenix_version >= 19:
+                try:
+                    pdb_fles = glob.glob("%s_real_space_refined_???.pdb"%(ccp4_name))
+                    # [fle for fle in os.listdir(os.getcwd()) if "%s_independent_real_space_refined_0"%(ccp4_name) in
+                    #            fle and fle.endswith('pdb')]
+                    pdb_fles.sort()
+                    outpdb = pdb_fles[-1]
+                except IndexError:
+                    outpdb = "%s_real_space_refined_000.pdb" % (ccp4_name)
+            else:
+                try:
+                    pdb_fles = glob.glob("%s_real_space_refined.pdb"%(ccp4_name))
+                    # [fle for fle in os.listdir(os.getcwd()) if
+                    #            "%s_independent_real_space_refined" % (ccp4_name) in fle and fle.endswith('pdb')]
+                    pdb_fles.sort()
+                    outpdb = pdb_fles[-1]
+                except IndexError:
+                    outpdb = "%s_real_space_refined.pdb" % (ccp4_name)
+        else: # os.system has not correctly finished
+            outpdb = "not_a_file"
+
+        return outpdb
+
         
     def get_solvent_content(self, pdb_in):
         """

--- a/phenix_refinements.py
+++ b/phenix_refinements.py
@@ -468,7 +468,8 @@ eof' % (mtz_out, ccp4_map_name))
         cycles with the refined model from phenix.refine.
         """
         mtz_for_dm, pdb_for_dm = self.write_refmac_for_dm(pdb_in)
-        mtz_out_dm = re.sub(r"for_dm.mtz$", "dm.mtz", mtz_for_dm)
+        #mtz_out_dm = re.sub(r"for_dm.mtz$", "dm.mtz", mtz_for_dm)
+        mtz_out_dm = re.sub(r".pdb$", "_dm.mtz", pdb_in)
         if (os.path.isfile(mtz_for_dm) and os.path.isfile(pdb_for_dm)):
             log_file = re.sub(r".mtz$", ".log", mtz_out_dm)
             script_dm = self.write_density_modification_script(mtz_for_dm, pdb_for_dm, mtz_out_dm, combine, cycles, log_file)

--- a/refiner.py
+++ b/refiner.py
@@ -793,7 +793,8 @@ eof' % (mtz_out, ccp4_map_name))
         cycles with the refined model from phenix.refine.
         """
         mtz_for_dm, pdb_for_dm = self.write_refmac_for_dm(pdb_in)
-        mtz_out_dm = re.sub(r"for_dm.mtz$", "dm.mtz", mtz_for_dm)
+        #mtz_out_dm = re.sub(r"for_dm.mtz$", "dm.mtz", mtz_for_dm)
+        mtz_out_dm = re.sub(r".pdb$", "_dm.mtz", pdb_in)
         if (os.path.isfile(mtz_for_dm) and os.path.isfile(pdb_for_dm)):
             log_file = re.sub(r".mtz$", ".log", mtz_out_dm)
             script_dm = self.write_density_modification_script(mtz_for_dm, pdb_for_dm, mtz_out_dm, log_file)

--- a/refiner.py
+++ b/refiner.py
@@ -1040,9 +1040,9 @@ def run(args):
             break
     global log
     log = open(logname, "w")
-    print("Xtrapol8 refiner -- run date: %s" %(now), file=log)
+    print("Xtrapol8 refiner -- Xtrapol8 version 1.2.1 -- run date: %s" %(now), file=log)
     print('-----------------------------------------')
-    print("Xtrapol8 refiner -- version 0.9 -- run date: %s" %(now))
+    print("Xtrapol8 refiner -- Xtrapol8 version 1.2.1 -- run date: %s" %(now))
     log_dir = os.getcwd()
     
     #Extract input from inputfile and command line


### PR DESCRIPTION
This pull request fixes an error in reciprocal space refinement when density modification is applied. In former versions the non-density modified columns were used for real space refinement. This is now surpassed by using the density-modified ccp4 map for real space refinement. For all non-density modified maps, the mtz file is passed to phenix.real_space_reffine or COOT.